### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/wand.el
+++ b/wand.el
@@ -5,6 +5,7 @@
 ;; Author: Duong H. Nguyen <cmpitgATgmail>
 ;; Keywords: extensions, tools
 ;; URL: https://github.com/cmpitg/wand
+;; Package-Requires: ((dash "2.5.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hi, I plan to add this to [MELPA](http://melpa.milkbox.net/). 

When installed as a package from an ELPA archive such as [MELPA](http://melpa.milkbox.net/), this header tells `package.el` to also install `dash`, which the library requires. For information about this fix, See [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).
